### PR TITLE
Remove leading and trailing white spaces

### DIFF
--- a/Sources/M3UKit/PlaylistParser.swift
+++ b/Sources/M3UKit/PlaylistParser.swift
@@ -77,7 +77,7 @@ public final class PlaylistParser {
 
       if self.isInfoLine(line) {
         lastMetadataLine = line
-      } else if let url = URL(string: line) {
+      } else if let url = URL(string: line.trimmingCharacters(in: .whitespaces)) {
         lastURL = url
       }
 


### PR DESCRIPTION
Remove leading and trailing white spaces that can cause the playlist to not parse due to wrong formatting of playlist