### PR TITLE
PlaylistParser. Add one or more spaces before duration

### DIFF
--- a/Sources/M3UKit/PlaylistParser.swift
+++ b/Sources/M3UKit/PlaylistParser.swift
@@ -317,7 +317,7 @@ public final class PlaylistParser {
 
   // MARK: - Regex
 
-  internal let durationRegex: RegularExpression = #"#EXTINF:(\-*\d+)"#
+  internal let durationRegex: RegularExpression = #"#EXTINF:\s*(\-*\d+)"#
   internal let nameRegex: RegularExpression = #".*,(.+?)$"#
 
   internal let mediaKindMoviesRegex: RegularExpression = #"\/movie\/"#


### PR DESCRIPTION
Hi! Some playlists have a space before duration. e.g #EXTINF: -1. I would be nice to cover such a case